### PR TITLE
Print newline when the day changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ lockunlock.sh {duration}
 ```
 duration: passed directly to `log show --last`, default 1d; 1 day. Can be any number of minutes (m), hours (h), or days (d).
 
-Tested to work on macOS 11.0 Big Sur and 10.15 Catalina. May also work on 10.14 Mojave.
+Tested to work on macOS 11.0 Big Sur, up to 13.0 Ventura.
 
 ![Screenshot](screen01.png)
 

--- a/lockunlock.sh
+++ b/lockunlock.sh
@@ -53,14 +53,21 @@ SEARCH_FOR="${LOCK_TERM}|${UNLOCK_TERM}|${SHUTDOWN_TERM}|${LOGIN_TERM}"
 content=$(log show --style syslog --predicate 'process == "loginwindow"' --debug --info --last ${PERIOD} | grep -E "${SEARCH_FOR}")
 green="\033[32m"
 red="\033[31m"
+day_previous=""
 while IFS= read -r line; do
     date=${line:0:19}
+    day=${line:0:10}
     reason=${line#*|}
     if [[ $reason == *"${LOCK_TERM}"* ]] || [[ $reason == *"${SHUTDOWN_TERM}"* ]]; then
         colour=${red}
     else
         colour=${green}
     fi
+    # Empty line when the day changes
+    if [[ $day_previous != "" ]] && [[ $day_previous != $day ]]; then
+        printf "\n"
+    fi
+    day_previous=$day
     printf "${colour}${date}  ${reason}\n"
 done <<< "${content}"
 printf "\033[0m"


### PR DESCRIPTION
I personally like to easily see when a day changes. 

Hope you like it as well:
![screenshot_separated_by_days](https://github.com/lesgrieve/lockunlock/assets/14351661/daf73f6d-b5d6-4bc4-a1fa-a47860123c25)
